### PR TITLE
[compiler] Fix warning.

### DIFF
--- a/mindy/compiler/feature.c
+++ b/mindy/compiler/feature.c
@@ -269,7 +269,7 @@ int yylex(void)
             new_token();
             break;
 
-          case (int)NULL:
+          case 0:
             while (State != NULL) {
                 error(State->line,
                       "#if with no matching #endif, assuming #endif at EOF.");


### PR DESCRIPTION
This commit fixes the following warning:

../mindy/compiler/feature.c: In function 'yylex':
../mindy/compiler/feature.c:272: warning: cast from pointer to integer
of different size
