### PR TITLE
[windows] Clean up. Make it compilable on MSVC and MinGW.

### DIFF
--- a/mindy/CMakeLists.txt
+++ b/mindy/CMakeLists.txt
@@ -21,6 +21,11 @@ OPTION(MINDY_USE_SIGNALS "Use signals." ${MINDY_USE_SIGNALS})
 CHECK_FUNCTION_EXISTS(_setjmp HAVE__SETJMP)
 CHECK_FUNCTION_EXISTS(_longjmp HAVE__LONGJMP)
 
+IF(MINGW)
+  # Workaround for bug: http://sourceforge.net/p/mingw-w64/bugs/406.
+  ADD_DEFINITIONS(-DMINGW_USE_BUILTIN_SETJMP_LONGJMP)
+ENDIF()
+
 # Linux provides this.
 CHECK_SYMBOL_EXISTS(sincos math.h HAVE_SINCOS)
 IF(NOT HAVE_SINCOS)
@@ -42,6 +47,10 @@ IF (NOT WIN32)
 ENDIF()
 
 CHECK_TYPE_SIZE("void*" SIZEOF_VOID_P)
+
+# MSVC doesn't provide these.
+CHECK_FUNCTION_EXISTS(strcasecmp HAVE_STRCASECMP)
+CHECK_FUNCTION_EXISTS(strncasecmp HAVE_STRNCASECMP)
 
 # Even though this is for the interpreter, we do this here
 # so that the results can make it into the config.h file.

--- a/mindy/compiler/dump.c
+++ b/mindy/compiler/dump.c
@@ -68,7 +68,7 @@ MINDY_INLINE static void dump_bytes(const void *ptr, int bytes)
 
     while (bytes > 0) {
         count = fwrite(ptr, 1, bytes, File);
-        ptr = ptr + count;
+        ptr = ((char*)ptr) + count;
         bytes -= count;
     }
 }

--- a/mindy/config.h.cmake
+++ b/mindy/config.h.cmake
@@ -1,5 +1,7 @@
 #cmakedefine HAVE__LONGJMP @HAVE__LONGJMP@
 #cmakedefine HAVE__SETJMP @HAVE__SETJMP@
+#cmakedefine HAVE_STRCASECMP @HAVE_STRCASECMP@
+#cmakedefine HAVE_STRNCASECMP @HAVE_STRNCASECMP@
 #cmakedefine HAVE_DAYLIGHT @HAVE_DAYLIGHT@
 #cmakedefine HAVE_LIBREADLINE @HAVE_LIBREADLINE@
 #cmakedefine HAVE_READLINE_READLINE_H @HAVE_READLINE_READLINE_H@
@@ -24,6 +26,16 @@
 #   define _longjmp longjmp
 #endif
 
-#ifdef _WIN32
+#ifdef MINGW_USE_BUILTIN_SETJMP_LONGJMP
+#   undef _setjmp
+#   define _setjmp __builtin_setjmp
+#   undef _longjmp
+#   define _longjmp __builtin_longjmp
+#endif
+
+#ifndef HAVE_STRCASECMP
 #   define strcasecmp stricmp
+#endif
+#ifndef HAVE_STRNCASECMP
+#   define strncasecmp strnicmp
 #endif

--- a/mindy/interpreter/load.c
+++ b/mindy/interpreter/load.c
@@ -137,13 +137,13 @@ static void read_bytes(struct load_info *info, void *ptr, int bytes)
         }
 
         memcpy(ptr, info->ptr, count);
-        ptr = ptr + count;
+        ptr = ((char*)ptr) + count;
         bytes -= count;
         info->ptr = info->end = info->buffer;
 
         while (bytes > BUFFER_SIZE) {
             count = safe_read(info, ptr, bytes);
-            ptr = ptr + count;
+            ptr = ((char*)ptr) + count;
             bytes -= count;
         }
 
@@ -985,7 +985,7 @@ void load(const char *name)
     if (strcmp(name, "-") == 0)
       fd = 0;
     else {
-#if WIN32
+#if _WIN32
       fd = open(name, O_RDONLY | O_BINARY, 0);
 #else
       fd = open(name, O_RDONLY, 0);

--- a/mindy/shared/portability.h
+++ b/mindy/shared/portability.h
@@ -41,8 +41,4 @@
 #define MINDY_INLINE
 #endif
 
-#ifdef _WIN32
-#define strncasecmp stricmp
-#endif
-
 #endif


### PR DESCRIPTION
 Hi

This will make `mindy` compile successfully on vc++ 2013 and MinGW 5.1. And can use `mindy -x` to run the demos*.

**note***: The mindy debugger doesn't seem to work on Windows. It always crashed with `error 122 ERROR_INSUFFICIENT_BUFFER`. I have to disabled it with the patch below just to make `mindy -x` run.

On my machine (Windows 7 64-bit), the `ReadFile` function doesn't return after first keyboard hit, but it will wait until we hit the `Enter` key.

```
diff --git a/mindy/interpreter/fd.c b/mindy/interpreter/fd.c
index 74080eb..ec276c3 100644
--- a/mindy/interpreter/fd.c
+++ b/mindy/interpreter/fd.c
@@ -104,6 +104,7 @@ static DWORD input_checker (LPDWORD param)
         bool read_result;
         /* Wait until someone invalidates our last answer */
         WaitForSingleObject(update_input_available[fd], INFINITE);
+#if 0
         /* Now loop until we complete a read without getting a
            broken pipe error */
         /* read 0 bytes, block if not available */
@@ -125,6 +126,7 @@ static DWORD input_checker (LPDWORD param)
             SuspendThread(fd_threads[fd]);
         }
         read_from = 1;
+#endif
     }
     lose("This is not supposed to be reached!");
     return 0;
```
