### PR TITLE
Initialize c-function's result_types to list of obj_ObjectClass.

### DIFF
--- a/mindy/interpreter/func.c
+++ b/mindy/interpreter/func.c
@@ -1199,7 +1199,7 @@ obj_t make_c_function(obj_t debug_name, void *pointer)
     C_FUNCTION(res)->restp = true;
     C_FUNCTION(res)->keywords = obj_False;
     C_FUNCTION(res)->all_keys = false;
-    C_FUNCTION(res)->result_types = obj_ObjectClass;
+    C_FUNCTION(res)->result_types = list1(obj_ObjectClass);
     C_FUNCTION(res)->more_results_type = obj_False;
     C_FUNCTION(res)->pointer = pointer;
     C_FUNCTION(res)->specializers = obj_Nil;


### PR DESCRIPTION
Hello,

I found this while trying to create a wrapper.
Not sure it's valid.
The `result_types` seems to expected a list. It crashes when calling `convert_c_object`.

snippet:

``` dylan
  load-object-file(list("test.dll"));
  let just_print = find-c-function("just_print");
  just_print();
  values();
```

test.c:

``` c
__declspec(dllexport)
void just_print()
{
    printf("print\n");
}
```

compiler: mingw64 on Windows 7
